### PR TITLE
ユーザー本登録エンドポイントのレスポンスに登録した本の情報を返すように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,12 @@ py -m pytest tests/integration/test_sample.py
 |:----:|:----|
 |isbn|登録対象の本のisbn13を指定|
 
+#### --レスポンスモデル
+`models.BookInfo`
+
 #### -- テスト
 国立国会図書館APIへの開発時のアクセス数を最低限に抑えるため、このエンドポイントへのテストは`.env`ファイル内の`NDLAPI_RELATED_TEST_EXECUTE_IS`をtrue(小文字に注意)にした場合にのみ実行される.
+
 
 ### - [get] /user/books
 - ユーザー所有本の一覧を取得するエンドポイント
@@ -240,6 +244,9 @@ py -m pytest tests/integration/test_sample.py
 |:----:|:----|
 |page|取得したいページ数|
 |size|1ページで取得したい要素数|
+
+#### --レスポンスモデル
+`list[models.UserBookInfo]`
 
 ## assetsカテゴリ
 ### - [get] /assets/thumbnails/{isbn}

--- a/mybrary-server/src/routers/users.py
+++ b/mybrary-server/src/routers/users.py
@@ -11,7 +11,7 @@ router = APIRouter(
 )
 
 
-@router.post("/books/register/")
+@router.post("/books/register/", response_model=schemas.BookInfo)
 async def register_book(
     isbn: str = Query(..., description = "登録したい本のisbnコード"),
     db: Session = Depends(get_db),
@@ -44,7 +44,7 @@ async def register_book(
             user_id=user_id,
             book_id=target_book.id
         )
-        return {"message": "本が正常に登録されました."}
+        return schemas.BookInfo.mapping_to_dict(crud.search_book_by_isbn(db=db, isbn=isbn))
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/mybrary-server/src/schemas/book.py
+++ b/mybrary-server/src/schemas/book.py
@@ -3,6 +3,48 @@ from pydantic import BaseModel, Field
 from src import models
 
 
+class BookInfo(BaseModel):
+    """Bookテーブルデータのレスポンスモデル
+
+    BaseClass:
+        BaseModel: pydanticの基盤クラス
+    """
+    id: str = Field(..., description="本のid")
+    isbn: str = Field(..., description="isbn13")
+    title: str = Field(..., description="本のタイトル")
+    creator: str = Field(..., description="著者")
+    publisher: str = Field(..., description="出版社")
+
+    def mapping_to_dict(target_book: models.Book) -> dict:
+        """Book型のオブジェクトをBookInfo型にマッピングする関数
+
+        Args:
+            target_book (models.Book): Bookテーブルから取得したレコードオブジェクト
+
+        Returns:
+            dict: BookInfo型のdict
+        """
+        return dict(
+            id = target_book.id,
+            isbn = target_book.isbn,
+            title = target_book.title,
+            creator = target_book.creator,
+            publisher = target_book.publisher
+        )
+    
+    class Config:
+        orm_mode = True
+        schema_extra = {
+            "example": {
+                "id": "book-0000-0000-0000-000000000000",
+                "isbn": "9780000000000",
+                "title": "Pythonの本",
+                "creator": "森田 林",
+                "publisher": "森林書房"
+            }
+        }
+
+
 class UserBookInfo(BaseModel):
     """ユーザー所有の本のレスポンスモデル
 

--- a/mybrary-server/tests/unit/test_assets.py
+++ b/mybrary-server/tests/unit/test_assets.py
@@ -23,7 +23,7 @@ def test_isbnコードが9784798167206である本の書影が正しく取得で
         response = client.post("/user/books/register/?isbn=9784798167206")
         res_json = response.json()
         assert response.status_code == 200
-        assert res_json["message"] == "本が正常に登録されました."
+        assert res_json["isbn"] == "9784798167206"
         
         response = client.get("/assets/thumbnails/9784798167206")
         assert response.status_code == 200
@@ -45,7 +45,7 @@ def test_isbnコードが9784785300019である書影がない本の書影が正
         response = client.post("/user/books/register/?isbn=9784785300019")
         res_json = response.json()
         assert response.status_code == 200
-        assert res_json["message"] == "本が正常に登録されました."
+        assert res_json["isbn"] == "9784785300019"
         
         response = client.get("/assets/thumbnails/9784785300019")
         assert response.status_code == 200

--- a/mybrary-server/tests/unit/test_users.py
+++ b/mybrary-server/tests/unit/test_users.py
@@ -39,7 +39,7 @@ def test_isbnコードが9784798067278である登録済みの本のユーザー
         response = client.post("/user/books/register/?isbn=9784798067278")
         res_json = response.json()
         assert response.status_code == 200
-        assert res_json["message"] == "本が正常に登録されました."
+        assert res_json["isbn"] == "9784798067278"
 
         with Session(bind=engine) as db:
             all_books = db.query(models.Book).all()
@@ -77,7 +77,7 @@ def test_isbnコードが9784798167206である未登録の本の登録とユー
         response = client.post("/user/books/register/?isbn=9784798167206")
         res_json = response.json()
         assert response.status_code == 200
-        assert res_json["message"] == "本が正常に登録されました."
+        assert res_json["isbn"] == "9784798167206"
         assert len(glob.glob("tests/tmp/9784798167206.jpg")) == 1
 
         with Session(bind=engine) as db:
@@ -116,7 +116,7 @@ def test_書影が登録されていない本のisbnコードである9784785300
         response = client.post("/user/books/register/?isbn=9784785300019")
         res_json = response.json()
         assert response.status_code == 200
-        assert res_json["message"] == "本が正常に登録されました."
+        assert res_json["isbn"] == "9784785300019"
         assert len(glob.glob("tests/tmp/9784785300019.jpg")) == 0
 
         with Session(bind=engine) as db:


### PR DESCRIPTION
# 概要
- スキーマを新たに定義しました
- ユーザー本登録エンドポイントのレスポンスとして登録した本の情報を返すようにしました
- テストの修正を行いました

# 技術的変更点
- BookInfo型のスキーマを新たに定義しました
- ユーザー本登録エンドポイントのレスポンスモデルをBookInfo型に設定しました
- エンドポイントのレスポンスモデル変更に伴うテストの修正を行いました

# 特に見てほしい点
- BookInfo型が適切かどうか
- テストが問題なく回るかどうか