### PR TITLE
ログイン中のユーザーの所属コミュニティ情報一覧を取得するエンドポイントの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,87 +221,79 @@ py -m pytest tests/integration/test_sample.py
 
 # エンドポイント一覧
 ## userカテゴリ
-### - [post] /user/books/register/
-- ユーザー所有の本を登録するエンドポイント
-
-#### -- クエリパラメータ
-|Query-param|detail|
-|:----:|:----|
-|isbn|登録対象の本のisbn13を指定|
-
-#### --レスポンスモデル
-`schemas.BookInfo`
-
-#### -- テスト
-国立国会図書館APIへの開発時のアクセス数を最低限に抑えるため、このエンドポイントへのテストは`.env`ファイル内の`NDLAPI_RELATED_TEST_EXECUTE_IS`をtrue(小文字に注意)にした場合にのみ実行される.
+>### - [post] /user/books/register/
+>- ユーザー所有の本を登録するエンドポイント
+>#### -- クエリパラメータ
+>|Query-param|detail|
+>|:----:|:----|
+>|isbn|登録対象の本のisbn13を指定|
+>#### --レスポンスモデル
+>`schemas.BookInfo`
+>#### -- テスト
+>国立国会図書館APIへの開発時のアクセス数を最低限に抑えるため、このエンドポイントへのテストは`.env`ファイル内の>`NDLAPI_RELATED_TEST_EXECUTE_IS`をtrue(小文字に注意)にした場合にのみ実行される.
 
 
-### - [get] /user/books
-- ユーザー所有本の一覧を取得するエンドポイント
-
-#### -- クエリパラメータ
-|Query-param|detail|
-|:----:|:----|
-|page|取得したいページ数|
-|size|1ページで取得したい要素数|
-
-#### --レスポンスモデル
-`list[schemas.UserBookInfo]`
+>### - [get] /user/books
+>- ユーザー所有本の一覧を取得するエンドポイント
+>#### -- クエリパラメータ
+>|Query-param|detail|
+>|:----:|:----|
+>|page|取得したいページ数|
+>|size|1ページで取得したい要素数|
+>#### --レスポンスモデル
+>`list[schemas.UserBookInfo]`
 
 
-### - [get] /books/{book_id}
-- 本の所有idによって指定された本の情報を返すエンドポイント
-
-#### --パスパラメータ
-|Path-param|detail|
-|:----:|:----|
-|book_id|取得対象の本のid|
-
-#### --レスポンスモデル
-`schemas.UserBookInfo`
+>### - [get] /user/books/{book_id}
+>- 本の所有idによって指定された本の情報を返すエンドポイント
+>#### --パスパラメータ
+>|Path-param|detail|
+>|:----:|:----|
+>|book_id|取得対象の本のid|
+>#### --レスポンスモデル
+>`schemas.UserBookInfo`
 
 
-### - [delete] /books/{book_id}
-- 本の所有idによって指定された本の削除を行うエンドポイント
+>### - [delete] /user/books/{book_id}
+>- 本の所有idによって指定された本の削除を行うエンドポイント
+>#### --パスパラメータ
+>|Path-param|detail|
+>|:----:|:----|
+>|book_id|削除対象の本のid|
+>#### 制限
+> - 指定された本の所有者のみがこのエンドポイントへのアクセス権限を有する.
 
-#### --パスパラメータ
-|Path-param|detail|
-|:----:|:----|
-|book_id|削除対象の本のid|
 
-#### 制限
-- 指定された本の所有者のみがこのエンドポイントへのアクセス権限を有する.
+> ### - [get] /user/communities
+> - ログイン中のユーザーが所属しているコミュニティの情報を配列で返すエンドポイント
+> #### --レスポンスモデル
+> `schemas.CommunityInfo`
 
 
 ## communityカテゴリ
-### - [post] /community/create
-- 新規コミュニティを作成するエンドポイント
+>### - [post] /community/create
+>- 新規コミュニティを作成するエンドポイント
+>#### リクエストボディモデル
+>`schemas.CommunitySetupInfo`
+>#### レスポンスモデル
+>`schemas.CommunityInfo`
 
-#### リクエストボディモデル
-`schemas.CommunitySetupInfo`
-
-#### レスポンスモデル
-`schemas.CommunityInfo`
-
-### - [post] /communities/{community_id}/add/{target_user_id}
-- コミュニティにユーザーを登録するエンドポイント
-
-#### -- パスパラメータ
-|Path-param|detail|
-|:----:|:----|
-|community_id|登録対象コミュニティのid|
-|target_user_id|登録対象ユーザーのid|
+>### - [post] /communities/{community_id}/add/{target_user_id}
+>- コミュニティにユーザーを登録するエンドポイント
+>#### -- パスパラメータ
+>|Path-param|detail|
+>|:----:|:----|
+>|community_id|登録対象コミュニティのid|
+>|target_user_id|登録対象ユーザーのid|
 
 
 ## assetsカテゴリ
-### - [get] /assets/thumbnails/{isbn}
-- isbn13によって指定された本の書影を取得するエンドポイント
-- 指定されたisbnコードの書影が存在しなかった場合はThumbnail-No-Found画像がレスポンスされる.
-
-#### -- パスパラメータ
-|Path-param|detail|
-|:----:|:----|
-|isbn|取得対象の本のisbn13|
-
-#### -- テスト
-国立国会図書館APIへの開発時のアクセス数を最低限に抑えるため、このエンドポイントへのテストは`.env`ファイル内の`NDLAPI_RELATED_TEST_EXECUTE_IS`をtrue(小文字に注意)にした場合にのみ実行される.
+>### - [get] /assets/thumbnails/{isbn}
+>- isbn13によって指定された本の書影を取得するエンドポイント
+>- 指定されたisbnコードの書影が存在しなかった場合はThumbnail-No-Found画像がレスポンスされる.
+>#### -- パスパラメータ
+>|Path-param|detail|
+>|:----:|:----|
+>|isbn|取得対象の本のisbn13|
+>#### -- テスト
+>国立国会図書館APIへの開発時のアクセス数を最低限に抑えるため、このエンドポイントへのテストは`.env`ファイル内の`NDLAPI_RELATED_TEST_EXECUTE_IS`をtrue(小文字に注意)にした場合にのみ実行される.

--- a/mybrary-server/src/routers/users.py
+++ b/mybrary-server/src/routers/users.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, HTTPException, Depends, Query
 from fastapi_pagination import Page, paginate
 from sqlalchemy.orm import Session
+from typing import List
 
 from src.dependencies import get_db, get_current_user, get_thumbnail_save_path
 from src import crud, services, schemas
@@ -95,6 +96,21 @@ async def delete_book_by_id(
             )
         crud.delete_user_book_by_id(db=db, book_id=book_id)
         return {"message": f"id:{book_id}の本を削除しました."}
+
+    except HTTPException as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    except:
+        raise HTTPException(status_code=500, detail="Internal Server Error")
+
+
+@router.get("/communities", response_model=List[schemas.CommunityInfo])
+async def get_belong_communities(
+    db: Session = Depends(get_db),
+    user_id: str = Depends(get_current_user)
+) -> str:
+    try:
+        belong_communities = crud.search_user_by_id(db=db, user_id=user_id).community
+        return list(map(schemas.CommunityInfo.mapping_to_dict, belong_communities))
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)


### PR DESCRIPTION
# 概要
- ログイン中のユーザーの所属コミュニティ情報一覧を取得するエンドポイントを追加しました
- READMEを更新しました

# 備考
- テストは後で追加します