### PR TITLE
コミュニティ単体情報を返すエンドポイントの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,11 @@ py -m pytest tests/integration/test_sample.py
 >|community_id|登録対象コミュニティのid|
 >|target_user_id|登録対象ユーザーのid|
 
+>### - [get] /communities/{community_id}
+>- コミュニティidで指定したコミュニティの情報を取得するエンドポイント
+>#### レスポンスモデル
+>`schemas.CommunityInfo`
+
 
 ## assetsカテゴリ
 >### - [get] /assets/thumbnails/{isbn}

--- a/mybrary-server/src/routers/communities.py
+++ b/mybrary-server/src/routers/communities.py
@@ -75,3 +75,19 @@ async def add_community_member(
         raise HTTPException(status_code=e.status_code, detail=e.detail)
     except:
         raise HTTPException(status_code=500, detail="Internal Server Error")
+
+
+@router.get("/communities/{community_id}")
+async def get_communitiy_info(
+    community_id: str,
+    db: Session = Depends(get_db),
+    user_id: str = Depends(get_current_user)
+):
+    try:
+        target_community = crud.search_community_by_id(db=db, community_id=community_id)
+        return schemas.CommunityInfo.mapping_to_dict(target_community=target_community, user_id=user_id)
+
+    except HTTPException as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
+    except:
+        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/mybrary-server/tests/unit/test_communities.py
+++ b/mybrary-server/tests/unit/test_communities.py
@@ -169,3 +169,52 @@ def test_user0003がcomm0004に存在しないユーザーuser0000を新規追�
 
     assert response.status_code == 404
     assert res_json["detail"] == "指定されたidのユーザーが見つかりませんでした."
+
+
+def test_comm0001のオーナーであるユーザーuser0003がcomm0001の情報を正常に取得できる():
+    """正常形テスト([get]/communities/{community_id})
+    1. ログイン中のユーザーをuser0003に変更する
+    2. コミュニティ1の情報をリクエストする
+    3. レスポンスのステータスコードとメッセージの確認
+    4. has_permissionがTrueであることの確認
+    """
+    app.dependency_overrides[get_current_user] = override_get_current_user0003
+    community_id = "comm0001-0000-0000-0000-000000000000"
+
+    response = client.get(f"/communities/{community_id}")
+    res_json = response.json()
+
+    assert response.status_code == 200
+    assert res_json["name"] == "コミュニティ1"
+    assert res_json["has_permission"] == True
+
+
+def test_ユーザーuser0001がcomm0001の情報を正常に取得できる():
+    """正常形テスト([get]/communities/{community_id})
+    1. コミュニティ1の情報をリクエストする
+    2. レスポンスのステータスコードとメッセージの確認
+    3. has_permissionがFalseであることの確認
+    """
+    community_id = "comm0001-0000-0000-0000-000000000000"
+
+    response = client.get(f"/communities/{community_id}")
+    res_json = response.json()
+
+    assert response.status_code == 200
+    assert res_json["name"] == "コミュニティ1"
+    assert res_json["has_permission"] == False
+
+
+def test_ユーザーuser0001が存在しないコミュニティcomm0000の情報をリクエストして404エラーを吐く():
+    """正常形テスト([get]/communities/{community_id})
+    1. コミュニティ1の情報をリクエストする
+    2. レスポンスのステータスコードとメッセージの確認
+    3. has_permissionがFalseであることの確認
+    """
+    community_id = "comm0000-0000-0000-0000-000000000000"
+
+    response = client.get(f"/communities/{community_id}")
+    res_json = response.json()
+
+    assert response.status_code == 404
+    assert res_json["detail"] == "指定されたidのコミュニティが見つかりませんでした."


### PR DESCRIPTION
# 概要
- コミュニティ単体情報を返すエンドポイントを追加しました
- テストを追加しました
- READMEを更新しました

# 技術的変更点
- コミュニティidで指定されたコミュニティの情報を返すエンドポイントを作成しました
- 当該エンドポイントのテストを追加しました