### PR TITLE
関数の最後の500エラーのraiseを削除しました

### DIFF
--- a/mybrary-server/src/crud/community.py
+++ b/mybrary-server/src/crud/community.py
@@ -58,8 +58,6 @@ def search_community_by_id(
             return target_community
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 def add_commynity_member(

--- a/mybrary-server/src/crud/user.py
+++ b/mybrary-server/src/crud/user.py
@@ -59,5 +59,3 @@ def search_user_by_id(
         return target_user
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/mybrary-server/src/routers/assets.py
+++ b/mybrary-server/src/routers/assets.py
@@ -29,5 +29,3 @@ async def get_image(
             return FileResponse("src/assets/default/thumbnail_not_found.jpg")
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/mybrary-server/src/routers/communities.py
+++ b/mybrary-server/src/routers/communities.py
@@ -37,8 +37,6 @@ async def create_community(
         )
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.post("/communities/{community_id}/add/{target_user_id}")
@@ -73,8 +71,6 @@ async def add_community_member(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.get("/communities/{community_id}")
@@ -89,5 +85,3 @@ async def get_communitiy_info(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/mybrary-server/src/routers/users.py
+++ b/mybrary-server/src/routers/users.py
@@ -34,8 +34,6 @@ async def create_user(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.post("/books/register/", response_model=schemas.UserBookInfo)
@@ -78,8 +76,6 @@ async def register_book(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.get("/books", response_model=Page[schemas.UserBookInfo])
@@ -92,8 +88,6 @@ async def get_user_books(
         return paginate(list(map(partial(schemas.UserBookInfo.mapping_to_dict, user_id=user_id), user_book)))
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.get("/books/{book_id}", response_model=schemas.UserBookInfo)
@@ -110,8 +104,6 @@ async def search_book_by_id(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.delete("/books/{book_id}")
@@ -132,8 +124,6 @@ async def delete_book_by_id(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @router.get("/communities", response_model=List[schemas.CommunityInfo])
@@ -147,5 +137,3 @@ async def get_belong_communities(
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)
-    except:
-        raise HTTPException(status_code=500, detail="Internal Server Error")


### PR DESCRIPTION
# 概要
- 予想外のエラー時に吸収して詳細が分からなくて邪魔だったので、関数の最後での500エラーのraiseを削除しました

# 技術的変更点
- エンドポイントのexceptの最後での500エラーのraiseを削除しました
- crud関数のexceptの最後での500エラーのraiseを削除しました