### PR TITLE
ユーザー本一覧取得エンドポイントのurl構造修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,23 +241,27 @@ py -m pytest tests/integration/test_sample.py
 >国立国会図書館APIへの開発時のアクセス数を最低限に抑えるため、このエンドポイントへのテストは`.env`ファイル内の>`NDLAPI_RELATED_TEST_EXECUTE_IS`をtrue(小文字に注意)にした場合にのみ実行される.
 
 
->### - [get] /user/books
+>### - [get] /user/{target_user_id}/books
 >- ユーザー所有本の一覧を取得するエンドポイント
 >#### -- クエリパラメータ
 >|Query-param|detail|
 >|:----:|:----|
 >|page|取得したいページ数|
 >|size|1ページで取得したい要素数|
+>#### --パスパラメータ
+>|Path-param|detail|
+>|:----:|:----|
+>|target_user_id|対象ユーザーのユーザーid|
 >#### --レスポンスモデル
 >`List[schemas.UserBookInfo]`
 
 
->### - [get] /user/books/{book_id}
+>### - [get] /user/books/{user_book_id}
 >- 本の所有idによって指定された本の情報を返すエンドポイント
 >#### --パスパラメータ
 >|Path-param|detail|
 >|:----:|:----|
->|book_id|取得対象の本のid|
+>|user_book_id|取得対象の本のid|
 >#### --レスポンスモデル
 >`schemas.UserBookInfo`
 

--- a/mybrary-server/src/crud/user_book.py
+++ b/mybrary-server/src/crud/user_book.py
@@ -45,18 +45,18 @@ def get_all_user_book(db: Session, user_id: str):
                 .all()
 
 
-def search_user_book_by_id(db: Session, book_id: str) -> models.UserBook:
+def search_user_book_by_id(db: Session, user_book_id: str) -> models.UserBook:
     """ユーザー所有の本をidで情報取得する関数
 
     Args:
         db (Session): DB接続用セッション
-        book_id (str): 取得対象の本のid
+        user_book_id (str): 取得対象の本のid
 
     Returns:
         models.UserBook: UserBookテーブルのレコードオブジェクト
     """
     target_book = db.query(models.UserBook)\
-        .filter(models.UserBook.id == book_id)\
+        .filter(models.UserBook.id == user_book_id)\
             .join(models.Book, models.UserBook.book_id == models.Book.id)\
                 .first()
     if target_book is None:

--- a/mybrary-server/src/routers/communities.py
+++ b/mybrary-server/src/routers/communities.py
@@ -8,7 +8,7 @@ from src.dependencies import get_db, get_current_user, get_thumbnail_save_path
 from src import crud, services, schemas
 
 router = APIRouter(
-    tags=['community']
+    tags=['communities']
 )
 
 

--- a/mybrary-server/src/routers/users.py
+++ b/mybrary-server/src/routers/users.py
@@ -78,13 +78,14 @@ async def register_book(
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
 
-@router.get("/books", response_model=Page[schemas.UserBookInfo])
+@router.get("/{target_user_id}/books", response_model=Page[schemas.UserBookInfo])
 async def get_user_books(
+    target_user_id: str,
     db: Session = Depends(get_db),
     user_id: str = Depends(get_current_user),
 ):  
     try:
-        user_book = crud.get_all_user_book(db=db, user_id=user_id)
+        user_book = crud.get_all_user_book(db=db, user_id=target_user_id)
         return paginate(list(map(partial(schemas.UserBookInfo.mapping_to_dict, user_id=user_id), user_book)))
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/mybrary-server/src/routers/users.py
+++ b/mybrary-server/src/routers/users.py
@@ -10,7 +10,7 @@ from src import crud, services, schemas
 
 router = APIRouter(
     prefix='/user',
-    tags=['user']
+    tags=['users']
 )
 
 

--- a/mybrary-server/src/routers/users.py
+++ b/mybrary-server/src/routers/users.py
@@ -70,7 +70,7 @@ async def register_book(
             book_id=target_book.id
         )
         return schemas.UserBookInfo.mapping_to_dict(
-            crud.search_user_book_by_id(db=db, book_id=registered_user_book_id),
+            crud.search_user_book_by_id(db=db, user_book_id=registered_user_book_id),
             user_id=user_id
         )
 
@@ -91,15 +91,15 @@ async def get_user_books(
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
 
-@router.get("/books/{book_id}", response_model=schemas.UserBookInfo)
+@router.get("/books/{user_book_id}", response_model=schemas.UserBookInfo)
 async def search_book_by_id(
-    book_id: str,
+    user_book_id: str,
     db: Session = Depends(get_db),
     user_id: str = Depends(get_current_user)
 ) -> schemas.UserBookInfo:
     try:
         return schemas.UserBookInfo.mapping_to_dict(
-            user_book = crud.search_user_book_by_id(db=db, book_id=book_id),
+            user_book = crud.search_user_book_by_id(db=db, user_book_id=user_book_id),
             user_id = user_id
         )
 
@@ -107,21 +107,21 @@ async def search_book_by_id(
         raise HTTPException(status_code=e.status_code, detail=e.detail)
 
 
-@router.delete("/books/{book_id}")
+@router.delete("/books/{user_book_id}")
 async def delete_book_by_id(
-    book_id: str,
+    user_book_id: str,
     db: Session = Depends(get_db),
     user_id: str = Depends(get_current_user)
 ) -> schemas.UserBookInfo:
     try:
-        target_book = crud.search_user_book_by_id(db=db, book_id=book_id)
+        target_book = crud.search_user_book_by_id(db=db, user_book_id=user_book_id)
         if target_book.user_id != user_id:
             raise HTTPException(
                 status_code=403,
                 detail="この本の削除機能へのアクセス権限がありません."
             )
-        crud.delete_user_book_by_id(db=db, book_id=book_id)
-        return {"message": f"id:{book_id}の本を削除しました."}
+        crud.delete_user_book_by_id(db=db, book_id=user_book_id)
+        return {"message": f"id:{user_book_id}の本を削除しました."}
 
     except HTTPException as e:
         raise HTTPException(status_code=e.status_code, detail=e.detail)

--- a/mybrary-server/tests/unit/test_users.py
+++ b/mybrary-server/tests/unit/test_users.py
@@ -206,32 +206,38 @@ def test_存在しない14桁のisbnコードである12345678901234を指定し
 
 
 
-def test_user0001が所有している本の一覧が正常に取得できる():
-    """正常系テスト([get]/user/books)
-    1. ログインユーザーを"user0001"に変更
+def test_user0002がuser0001の所有している本の一覧が正常に取得できる():
+    """正常系テスト([get]/user/{target_user_id}/books)
+    1. ログインユーザーを"user0002"に変更
     2. "user0001"が所有している本の一覧をリクエスト
     3. "user0001"が所有している本が3冊取得されることを確認
     """
-    response = client.get("/user/books?page=1&size=50")
+    app.dependency_overrides[get_current_user] = override_get_current_user0002
+    target_user_id = "user0001-0000-0000-0000-000000000000"
+    response = client.get(f"/user/{target_user_id}/books?page=1&size=50")
     res_json = response.json()
     assert response.status_code == 200
     assert len(res_json["items"]) == 0
 
 
-def test_user0002が所有している本の一覧が正常に取得できる():
-    """正常系テスト([get]/user/books)
+def test_user0002が自身の所有している本の一覧が正常に取得できる():
+    """正常系テスト([get]/user/{target_user_id}/books)
     1. ログインユーザーを"user0002"に変更
     2. "user0002"が所有している本の一覧をリクエスト
     3. "user0002"が所有している本が3冊取得されることを確認
     """
     app.dependency_overrides[get_current_user] = override_get_current_user0002
-    response = client.get("/user/books?page=1&size=50")
+    target_user_id = "user0002-0000-0000-0000-000000000000"
+    response = client.get(f"/user/{target_user_id}/books?page=1&size=50")
     res_json = response.json()
     assert response.status_code == 200
     assert len(res_json["items"]) == 3
     assert res_json["items"][0]["book_id"] == "book0001-0000-0000-0000-000000000000"
     assert res_json["items"][1]["book_id"] == "book0002-0000-0000-0000-000000000000"
     assert res_json["items"][2]["book_id"] == "book0003-0000-0000-0000-000000000000"
+    assert res_json["items"][0]["has_permission"] == True
+    assert res_json["items"][1]["has_permission"] == True
+    assert res_json["items"][2]["has_permission"] == True
 
 
 def test_本の所有idがusbk0001の本の情報を正常に取得できる():


### PR DESCRIPTION
# 概要
- ユーザー本一覧取得エンドポイントのurl構造修正

# 技術的変更点
- "/user/books"→"/user/{target_user_id}/books"
- ユーザーの所有している本の所有idをbook_id→user_book_idに変更しました
　→本自体の固有idとのみわけがつかずめんどくさかったため